### PR TITLE
fix words to be composed of letters, digits and underscores in taglist

### DIFF
--- a/lib/stratum/model.rb
+++ b/lib/stratum/model.rb
@@ -984,7 +984,7 @@ module Stratum
                   if v
                     words = [v].flatten
                     strict_equality_checks.push(Proc.new{|obj| words.inject(true){|r,s| r and obj.send(k).include?(s)}})
-                    words.flatten.map{|s| s.split(/[^0-9a-zA-Z]/)}.flatten.map{|s| '+' + s}.join(' ')
+                    words.flatten.map{|s| s.split(/[^0-9a-zA-Z_]/)}.flatten.map{|s| '+' + s}.join(' ')
                   else
                     nil
                   end


### PR DESCRIPTION
word must be composed of letters, digits and underscores, but now word is compesed of only letters and digits.

http://dev.mysql.com/doc/refman/5.7/en/fulltext-natural-language.html

> The MySQL FULLTEXT implementation regards any sequence of true word characters (letters, digits, and underscores) as a word.

using yabitz, I couldn't search tag includes underscore.
